### PR TITLE
Add Vue compatibility with stubs and enhance Rollup config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "easy-ai18n",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Client SDK for AI-powered i18n translation service",
     "type": "module",
     "main": "dist/index.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,12 +15,17 @@ export default [
       exports: "named",
     },
     plugins: [
-      peerDepsExternal(),
+      peerDepsExternal({
+        includeDependencies: true,
+      }),
       babel({
         babelHelpers: "bundled",
         exclude: "node_modules/**",
       }),
-      resolve(),
+      resolve({
+        // Prefer built-in modules
+        preferBuiltins: true,
+      }),
       commonjs(),
     ],
     external: ["react", "react-dom", "vue"],
@@ -35,12 +40,17 @@ export default [
       exports: "named",
     },
     plugins: [
-      peerDepsExternal(),
+      peerDepsExternal({
+        includeDependencies: true,
+      }),
       babel({
         babelHelpers: "bundled",
         exclude: "node_modules/**",
       }),
-      resolve(),
+      resolve({
+        // Prefer built-in modules
+        preferBuiltins: true,
+      }),
       commonjs(),
     ],
     external: ["react", "react-dom", "vue"],
@@ -60,13 +70,17 @@ export default [
       },
     },
     plugins: [
-      peerDepsExternal(),
+      peerDepsExternal({
+        includeDependencies: true,
+      }),
       babel({
         babelHelpers: "bundled",
         exclude: "node_modules/**",
       }),
       resolve({
         browser: true,
+        // Prefer built-in modules
+        preferBuiltins: true,
       }),
       commonjs(),
       terser(),

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import I18nClient from "./core";
 import * as reactComponents from "./react";
-import * as vueComponents from "./vue";
 
 // Export core client
 export default I18nClient;
@@ -13,6 +12,29 @@ export const {
   Translate,
   LanguageSelector,
 } = reactComponents;
+
+// Conditionally export Vue components if Vue is available
+let vueComponents = null;
+try {
+  // This will fail silently if Vue is not available
+  vueComponents = require("./vue").default;
+} catch (e) {
+  // Vue is not available, provide stub components
+  vueComponents = {
+    createI18n: () => {
+      console.warn("Vue is not available. Install Vue to use Vue components.");
+      return {};
+    },
+    useI18n: () => {
+      console.warn("Vue is not available. Install Vue to use Vue components.");
+      return {};
+    },
+    useTranslation: () => {
+      console.warn("Vue is not available. Install Vue to use Vue components.");
+      return { text: "", isLoading: false, error: null };
+    },
+  };
+}
 
 // Export Vue components
 export const {

--- a/src/vue/index.js
+++ b/src/vue/index.js
@@ -1,4 +1,20 @@
-import { ref, reactive, provide, inject, watch, onMounted } from "vue";
+// Try to import Vue, but handle case when it's not available
+let vue;
+try {
+  vue = require("vue");
+} catch (e) {
+  // Vue is not available, provide stubs
+  vue = {
+    ref: () => ({}),
+    reactive: (obj) => obj,
+    provide: () => {},
+    inject: () => {},
+    watch: () => {},
+    onMounted: (fn) => {},
+  };
+}
+
+const { ref, reactive, provide, inject, watch, onMounted } = vue;
 import I18nClient from "../core";
 
 const I18N_SYMBOL = Symbol("i18n");
@@ -144,3 +160,10 @@ export function useTranslation(textOrRef, options = {}) {
     error,
   };
 }
+
+// Export as default object for conditional imports
+export default {
+  createI18n,
+  useI18n,
+  useTranslation,
+};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -115,26 +115,26 @@ export function LanguageSelector(props: {
   className?: string;
 }): JSX.Element;
 
-// Vue component types
+// Vue component types (available only when Vue is installed)
 export function createI18n(config: I18nClientConfig): {
   client: I18nClient;
-  targetLanguage: import('vue').Ref<string>;
-  sourceLanguage: import('vue').Ref<string>;
-  isLoaded: import('vue').Ref<boolean>;
-  languages: import('vue').Ref<Language[]>;
+  targetLanguage: any; // Use 'any' instead of direct Vue import
+  sourceLanguage: any;
+  isLoaded: any;
+  languages: any;
   setTargetLanguage: (language: string) => void;
   translate: (text: string, options?: TranslateOptions) => Promise<string>;
 };
 
-export function useI18n(): ReturnType<typeof createI18n>;
+export function useVueI18n(): ReturnType<typeof createI18n>;
 
 export function useTranslation(
-  textOrRef: string | (() => string) | import('vue').Ref<string>,
+  textOrRef: string | (() => string) | any, // Use 'any' instead of direct Vue import
   options?: TranslateOptions
 ): {
-  text: import('vue').Ref<string>;
-  isLoading: import('vue').Ref<boolean>;
-  error: import('vue').Ref<string | null>;
+  text: any; // Use 'any' instead of direct Vue import
+  isLoading: any;
+  error: any;
 };
 
 // Default export


### PR DESCRIPTION
Introduce conditional exports for Vue components and improve compatibility by using stubs when Vue is unavailable. Update Rollup configuration to better handle dependencies and built-in modules. Bump version to 0.1.1.